### PR TITLE
Add FileID, Inline attributes to attachments in GenericInterface

### DIFF
--- a/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
+++ b/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
@@ -116,12 +116,16 @@ perform PublicFAQGet Operation. This will return a Public FAQ entry.
                             ContentType => 'image/jpeg',
                             Filename    => 'Error.jpg',
                             Content     => '...'                    # base64 content
+                            Inline      => 0,                       # inline attachment?
+                            FileID      => 34                       
                         },
                         {
                             Filesize    => '540286',                # file size in bytes
                             ContentType => 'image/jpeg',
                             Filename    => 'Pencil.jpg',
-                            Content     => '...'                    # base64 content
+                            Content     => '...',                    # base64 content
+                            Inline      => 0,                       # inline attachment?
+                            FileID      => 34                       
                         },
                     },
                 },

--- a/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
+++ b/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
@@ -115,7 +115,7 @@ perform PublicFAQGet Operation. This will return a Public FAQ entry.
                             Filesize    => '540286',                # file size in bytes
                             ContentType => 'image/jpeg',
                             Filename    => 'Error.jpg',
-                            Content     => '...'                    # base64 content
+                            Content     => '...',                    # base64 content
                             Inline      => 0,                       # inline attachment?
                             FileID      => 34                       
                         },

--- a/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
+++ b/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
@@ -261,7 +261,8 @@ sub Run {
                         FileID => $Attachment->{FileID},
                         UserID => $UserID,
                     );
-
+                    $File{FileID} = $Attachment->{FileID}
+                    $File{Inline} = $Attachment->{Inline}
                     # convert content to base64
                     $File{Content} = encode_base64( $File{Content} );
                 }
@@ -270,7 +271,9 @@ sub Run {
                         Filename    => $Attachment->{Filename},
                         ContentType => $Attachment->{ContentType},
                         Filesize    => $Attachment->{Filesize},
-                        Content     => ''
+                        Content     => '',
+                        FileID      => $Attachment->{FileID},
+                        Inline      => $Attachment->{Inline},
                     );
                 }
                 push @Attachments, {%File};

--- a/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
+++ b/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
@@ -261,8 +261,8 @@ sub Run {
                         FileID => $Attachment->{FileID},
                         UserID => $UserID,
                     );
-                    $File{FileID} = $Attachment->{FileID}
-                    $File{Inline} = $Attachment->{Inline}
+                    $File{FileID} = $Attachment->{FileID};
+                    $File{Inline} = $Attachment->{Inline};
                     # convert content to base64
                     $File{Content} = encode_base64( $File{Content} );
                 }

--- a/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
+++ b/Kernel/GenericInterface/Operation/FAQ/PublicFAQGet.pm
@@ -273,7 +273,7 @@ sub Run {
                         Filesize    => $Attachment->{Filesize},
                         Content     => '',
                         FileID      => $Attachment->{FileID},
-                        Inline      => $Attachment->{Inline},
+                        Inline      => $Attachment->{Inline}
                     );
                 }
                 push @Attachments, {%File};

--- a/doc/en/FAQ.xml
+++ b/doc/en/FAQ.xml
@@ -1861,6 +1861,8 @@ shell> $OTRS_HOME/bin/otrs.WebserviceConfig.pl -a list
                <Filesize>?</Filesize>
                <ContentType>?</ContentType>
                <Content>cid:1269416154096</Content>
+               <Inline>?</Inline>
+               <FileID>?</FileID>
             </Attachment>
          </FAQItem>
       </PublicFAQGetResponse>
@@ -1909,12 +1911,16 @@ shell> $OTRS_HOME/bin/otrs.WebserviceConfig.pl -a list
                 <ContentType>text/plain</ContentType>
                 <Filename>Details.txt</Filename>
                 <Filesize>296</Filesize>
+               <Inline>0</Inline>
+               <FileID>4</FileID>
              </Attachment>
              <Attachment>
                 <Content>...==</Content>
                 <ContentType>text/plain</ContentType>
                 <Filename>Text.bin</Filename>
                 <Filesize>980</Filesize>
+               <Inline>0</Inline>
+               <FileID>5</FileID>
              </Attachment>
           </FAQItem>
           <FAQItem>


### PR DESCRIPTION
Add FileID, Inline attributes to attachments in GenericInterface for use with the SOAP API.
This allows to distinguish between inline files and attachments. Moreover, files can be identified.