### PR TITLE
Master - added class for invalid FAQ entities in overview tables

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentFAQCategory.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentFAQCategory.tt
@@ -63,7 +63,7 @@
                         </tr>
 [% RenderBlockEnd("NoDataFoundMsg") %]
 [% RenderBlockStart("OverviewResultRow") %]
-                        <tr>
+                        <tr [% IF Data.Valid != 'valid'%]class="Invalid"[% END %] >
                             <td><a class="AsBlock" href="[% Env("Baselink") %]Action=[% Env("Action") %];Subaction=Change;CategoryID=[% Data.CategoryID | uri %]">[% Data.Name | html %]</a></td>
                             <td>[% Translate(Data.Valid) | html %]</td>
                             <td class="Center Last">

--- a/Kernel/Output/HTML/Templates/Standard/AgentFAQOverviewSmall.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentFAQOverviewSmall.tt
@@ -94,7 +94,7 @@
         </thead>
         <tbody>
 [% RenderBlockStart("Record") %]
-            <tr id="ItemID_[% Data.ItemID | html %]_[% Data.Counter | html %]" class="MasterAction">
+            <tr id="ItemID_[% Data.ItemID | html %]_[% Data.Counter | html %]" class="MasterAction[% IF Data.ValidID != 1%] Invalid[% END %]" >
 [% RenderBlockStart("RecordNumber") %]
                 <td>
 [% RenderBlockStart("RecordNumberLinkStart") %]

--- a/var/httpd/htdocs/skins/Agent/default/css/FAQ.Agent.Default.css
+++ b/var/httpd/htdocs/skins/Agent/default/css/FAQ.Agent.Default.css
@@ -103,5 +103,9 @@ fieldset.TableSmall > div.FAQDivider {
     margin-right: auto;
 }
 
+.TableSmall tbody tr.Invalid {
+    color: #CCC;
+}
+
 }
 


### PR DESCRIPTION
Hi @carlosfrodriguez 

In this PR is added Invalid class for invalid entities ( the raw is grayed, as in OTRS)
As you can see, there are update only for Agent interface, because in public and customer interface only valid FAQ is displayed.  
On this way, Search and Category screen is changed.
If you have any suggestion please let me know.

Regards
Zoran