### PR TITLE
Master - FAQ modernize input fields

### DIFF
--- a/Kernel/Modules/AgentFAQAdd.pm
+++ b/Kernel/Modules/AgentFAQAdd.pm
@@ -494,6 +494,7 @@ sub _MaskNew {
         Data       => \%ValidList,
         Name       => 'ValidID',
         SelectedID => $Param{ValidID} || $ValidListReverse{valid},
+        Class      => 'Modernize',
     );
 
     # set no server error class as default
@@ -508,6 +509,7 @@ sub _MaskNew {
         Class        => 'Validate_Required ' . $Param{CategoryIDServerError},
         Translation  => 0,
         TreeView     => 1,
+        Class        => 'Modernize',
     );
 
     # get FAQ object
@@ -553,6 +555,7 @@ sub _MaskNew {
         Name          => 'LanguageID',
         SelectedValue => $SelectedLanguage,
         Translation   => 0,
+        Class         => 'Modernize',
     );
 
     # get the states list
@@ -579,6 +582,7 @@ sub _MaskNew {
         Name          => 'StateID',
         SelectedValue => $SelectedState,
         Translation   => 1,
+        Class         => 'Modernize',
     );
 
     # show FAQ add screen
@@ -667,6 +671,7 @@ sub _MaskNew {
                     1 => 'Yes',
                 },
                 SelectedID => $Param{Approved} || 0,
+                Class => 'Modernize',
             );
             $LayoutObject->Block(
                 Name => 'Approval',

--- a/Kernel/Modules/AgentFAQCategory.pm
+++ b/Kernel/Modules/AgentFAQCategory.pm
@@ -638,6 +638,7 @@ sub _Edit {
         Data       => \%ValidList,
         Name       => 'ValidID',
         SelectedID => $Param{ValidID} || $ValidListReverse{valid},
+        Class      => 'Modernize',
     );
 
     # get all valid groups
@@ -655,6 +656,7 @@ sub _Edit {
         Multiple   => 1,
         Class      => 'Validate_Required ' . $Param{PermissionGroupsServerError},
         SelectedID => $Param{PermissionGroups},
+        Class      => 'Modernize',
     );
 
     # get all categories with their long names
@@ -671,6 +673,7 @@ sub _Edit {
         PossibleNone   => 1,
         DisabledBranch => $CategoryTree->{ $Param{CategoryID} } || '',
         Translation    => 0,
+        Class          => 'Modernize',
     );
 
     $LayoutObject->Block(

--- a/Kernel/Modules/AgentFAQEdit.pm
+++ b/Kernel/Modules/AgentFAQEdit.pm
@@ -730,6 +730,7 @@ sub _MaskNew {
         Data       => \%ValidList,
         Name       => 'ValidID',
         SelectedID => $Param{ValidID} || $ValidListReverse{valid},
+        Class      => 'Modernize',
     );
 
     # get FAQ object
@@ -750,7 +751,7 @@ sub _MaskNew {
         Name         => 'CategoryID',
         SelectedID   => $Param{CategoryID},
         PossibleNone => 1,
-        Class        => 'Validate_Required ' . $Param{CategoryIDServerError},
+        Class        => 'Validate_Required Modernize' . $Param{CategoryIDServerError},
         Translation  => 0,
         TreeView     => $TreeView,
     );
@@ -795,6 +796,7 @@ sub _MaskNew {
         Name          => 'LanguageID',
         SelectedValue => $SelectedLanguage,
         Translation   => 0,
+        Class         => 'Modernize',
     );
 
     # get the states list
@@ -821,6 +823,7 @@ sub _MaskNew {
         Name          => 'StateID',
         SelectedValue => $SelectedState,
         Translation   => 1,
+        Class         => 'Modernize',
     );
 
     # get screen type
@@ -885,6 +888,7 @@ sub _MaskNew {
                     1 => 'Yes',
                 },
                 SelectedID => $Param{Approved} || 0,
+                Class => 'Modernize',
             );
             $LayoutObject->Block(
                 Name => 'Approval',

--- a/Kernel/Modules/AgentFAQSearch.pm
+++ b/Kernel/Modules/AgentFAQSearch.pm
@@ -1324,11 +1324,13 @@ sub _MaskForm {
         Data     => \@Attributes,
         Name     => 'Attribute',
         Multiple => 0,
+        Class    => 'Modernize',
     );
     $Param{AttributesOrigStrg} = $LayoutObject->BuildSelection(
         Data     => \@Attributes,
         Name     => 'AttributeOrig',
         Multiple => 0,
+        Class    => 'Modernize',
     );
 
     # get FAQ object
@@ -1343,9 +1345,9 @@ sub _MaskForm {
     $Param{LanguagesSelectionStrg} = $LayoutObject->BuildSelection(
         Data       => \%Languages,
         Name       => 'LanguageIDs',
-        Size       => 5,
         Multiple   => 1,
         SelectedID => $GetParam{LanguageIDs} || [],
+        Class      => 'Modernize',
     );
 
     # get categories (with category long names) where user has rights
@@ -1359,10 +1361,10 @@ sub _MaskForm {
         Data        => $UserCategoriesLongNames,
         Name        => 'CategoryIDs',
         SelectedID  => $GetParam{CategoryIDs} || [],
-        Size        => 5,
         Translation => 0,
         Multiple    => 1,
         TreeView    => $TreeView,
+        Class       => 'Modernize',
     );
 
     # get valid list
@@ -1373,9 +1375,9 @@ sub _MaskForm {
         Data        => \%ValidList,
         Name        => 'ValidIDs',
         SelectedID  => $GetParam{ValidIDs} || [],
-        Size        => 5,
         Translation => 0,
         Multiple    => 1,
+        Class       => 'Modernize',
     );
 
     # create a mix of state and state types hash in order to have the state type IDs with state
@@ -1397,9 +1399,9 @@ sub _MaskForm {
         Data        => \%States,
         Name        => 'StateIDs',
         SelectedID  => $GetParam{StateIDs} || [],
-        Size        => 3,
         Translation => 1,
         Multiple    => 1,
+        Class       => 'Modernize',
     );
 
     my %VotingOperators = (
@@ -1414,18 +1416,18 @@ sub _MaskForm {
         Data        => \%VotingOperators,
         Name        => 'VoteSearchType',
         SelectedID  => $GetParam{VoteSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{RateSearchTypeSelectionStrg} = $LayoutObject->BuildSelection(
         Data        => \%VotingOperators,
         Name        => 'RateSearchType',
         SelectedID  => $GetParam{RateSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
     $Param{RateSearchSelectionStrg} = $LayoutObject->BuildSelection(
         Data => {
@@ -1438,9 +1440,9 @@ sub _MaskForm {
         Sort        => 'NumericKey',
         Name        => 'RateSearch',
         SelectedID  => $GetParam{RateSearch} || '',
-        Size        => 1,
         Translation => 0,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{ApprovedStrg} = $LayoutObject->BuildSelection(
@@ -1452,6 +1454,7 @@ sub _MaskForm {
         SelectedID  => $GetParam{ApprovedSearch} || 'Yes',
         Multiple    => 0,
         Translation => 1,
+        Class       => 'Modernize',
     );
 
     # get a list of all users to display
@@ -1486,15 +1489,15 @@ sub _MaskForm {
         Data       => \%ShownUsers,
         Name       => 'CreatedUserIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $GetParam{CreatedUserIDs},
+        Class      => 'Modernize',
     );
     $Param{LastChangedUserStrg} = $LayoutObject->BuildSelection(
         Data       => \%ShownUsers,
         Name       => 'LastChangedUserIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $GetParam{LastChangedUserIDs},
+        Class      => 'Modernize',
     );
 
     $Param{ItemCreateTimePointStrg} = $LayoutObject->BuildSelection(
@@ -1588,6 +1591,7 @@ sub _MaskForm {
         Name       => 'Profile',
         ID         => 'SearchProfile',
         SelectedID => $Profile,
+        Class      => 'Modernize',
     );
 
     $Param{ResultFormStrg} = $LayoutObject->BuildSelection(
@@ -1598,6 +1602,7 @@ sub _MaskForm {
         },
         Name       => 'ResultForm',
         SelectedID => $GetParam{ResultForm} || 'Normal',
+        Class      => 'Modernize',
     );
 
     # HTML search mask output

--- a/Kernel/Modules/AgentFAQSearchSmall.pm
+++ b/Kernel/Modules/AgentFAQSearchSmall.pm
@@ -712,6 +712,7 @@ sub _MaskForm {
         PossibleNone => 1,
         Name         => 'Profile',
         SelectedID   => $Param{Profile},
+        Class        => 'Modernize',
     );
 
     # get FAQ object
@@ -726,9 +727,9 @@ sub _MaskForm {
     $Param{LanguagesSelectionStrg} = $LayoutObject->BuildSelection(
         Data       => \%Languages,
         Name       => 'LanguageIDs',
-        Size       => 5,
         Multiple   => 1,
         SelectedID => $Param{LanguageIDs} || [],
+        Class      => 'Modernize',
     );
 
     # get categories (with category long names) where user has rights
@@ -742,10 +743,10 @@ sub _MaskForm {
         Data        => $UserCategoriesLongNames,
         Name        => 'CategoryIDs',
         SelectedID  => $Param{CategoryIDs} || [],
-        Size        => 5,
         Translation => 0,
         Multiple    => 1,
         TreeView    => $TreeView,
+        Class       => 'Modernize',
     );
 
     # get valid list
@@ -756,9 +757,9 @@ sub _MaskForm {
         Data        => \%ValidList,
         Name        => 'ValidIDs',
         SelectedID  => $Param{ValidIDs} || [],
-        Size        => 5,
         Translation => 0,
         Multiple    => 1,
+        Class       => 'Modernize',
     );
 
     # create a mix of state and state types hash in order to have the state type IDs with state
@@ -780,9 +781,9 @@ sub _MaskForm {
         Data        => \%States,
         Name        => 'StateIDs',
         SelectedID  => $Param{StateIDs} || [],
-        Size        => 3,
         Translation => 1,
         Multiple    => 1,
+        Class       => 'Modernize',
     );
 
     my %VotingOperators = (
@@ -797,18 +798,18 @@ sub _MaskForm {
         Data        => \%VotingOperators,
         Name        => 'VoteSearchType',
         SelectedID  => $Param{VoteSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{RateSearchTypeSelectionStrg} = $LayoutObject->BuildSelection(
         Data        => \%VotingOperators,
         Name        => 'RateSearchType',
         SelectedID  => $Param{RateSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
     $Param{RateSearchSelectionStrg} = $LayoutObject->BuildSelection(
         Data => {
@@ -821,9 +822,9 @@ sub _MaskForm {
         Sort        => 'NumericKey',
         Name        => 'RateSearch',
         SelectedID  => $Param{RateSearch} || '',
-        Size        => 1,
         Translation => 0,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{ApprovedStrg} = $LayoutObject->BuildSelection(
@@ -836,6 +837,7 @@ sub _MaskForm {
         Multiple     => 0,
         Translation  => 1,
         PossibleNone => 1,
+        Class        => 'Modernize',
     );
 
     # get a list of all users to display
@@ -870,15 +872,15 @@ sub _MaskForm {
         Data       => \%ShownUsers,
         Name       => 'CreatedUserIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{CreatedUserIDs},
+        Class      => 'Modernize',
     );
     $Param{LastChangedUserStrg} = $LayoutObject->BuildSelection(
         Data       => \%ShownUsers,
         Name       => 'LastChangedUserIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{LastChangedUserIDs},
+        Class      => 'Modernize',
     );
 
     $Param{ItemCreateTimePointStrg} = $LayoutObject->BuildSelection(

--- a/Kernel/Modules/CustomerFAQSearch.pm
+++ b/Kernel/Modules/CustomerFAQSearch.pm
@@ -1409,6 +1409,7 @@ sub MaskForm {
         Data       => {%ResultForm},
         Name       => 'ResultForm',
         SelectedID => $Param{ResultForm} || 'Normal',
+        Class      => 'Modernize',
     );
 
     # get profiles list
@@ -1423,6 +1424,7 @@ sub MaskForm {
         PossibleNone => 1,
         Name         => 'Profile',
         SelectedID   => $Param{Profile},
+        Class        => 'Modernize',
     );
 
     # get FAQ object
@@ -1438,8 +1440,8 @@ sub MaskForm {
         Data       => {%Languages},
         Name       => 'LanguageIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{LanguageIDs},
+        Class      => 'Modernize',
     );
 
     # get categories list
@@ -1454,9 +1456,9 @@ sub MaskForm {
         Data       => $Categories,
         Name       => 'CategoryIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{CategoryIDs},
         TreeView   => $TreeView,
+        Class      => 'Modernize',
     );
 
     my %VotingOperators = (
@@ -1471,18 +1473,18 @@ sub MaskForm {
         Data        => \%VotingOperators,
         Name        => 'VoteSearchType',
         SelectedID  => $Param{VoteSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{RateSearchTypeSelectionString} = $LayoutObject->BuildSelection(
         Data        => \%VotingOperators,
         Name        => 'RateSearchType',
         SelectedID  => $Param{RateSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
     $Param{RateSearchSelectionString} = $LayoutObject->BuildSelection(
         Data => {
@@ -1495,9 +1497,9 @@ sub MaskForm {
         Sort        => 'NumericKey',
         Name        => 'RateSearch',
         SelectedID  => $Param{RateSearch} || '',
-        Size        => 1,
         Translation => 0,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{ItemCreateTimePoint} = $LayoutObject->BuildSelection(

--- a/Kernel/Modules/PublicFAQSearch.pm
+++ b/Kernel/Modules/PublicFAQSearch.pm
@@ -1376,6 +1376,7 @@ sub MaskForm {
         Data       => {%ResultForm},
         Name       => 'ResultForm',
         SelectedID => $Param{ResultForm} || 'Normal',
+        Class      => 'Modernize',
     );
 
     # get FAQ object
@@ -1391,8 +1392,8 @@ sub MaskForm {
         Data       => {%Languages},
         Name       => 'LanguageIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{LanguageIDs},
+        Class      => 'Modernize',
     );
 
     # get categories list
@@ -1407,9 +1408,9 @@ sub MaskForm {
         Data       => $Categories,
         Name       => 'CategoryIDs',
         Multiple   => 1,
-        Size       => 5,
         SelectedID => $Param{CategoryIDs},
         TreeView   => $TreeView,
+        Class      => 'Modernize',
     );
 
     my %VotingOperators = (
@@ -1424,18 +1425,18 @@ sub MaskForm {
         Data        => \%VotingOperators,
         Name        => 'VoteSearchType',
         SelectedID  => $Param{VoteSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{RateSearchTypeSelectionString} = $LayoutObject->BuildSelection(
         Data        => \%VotingOperators,
         Name        => 'RateSearchType',
         SelectedID  => $Param{RateSearchType} || '',
-        Size        => 1,
         Translation => 1,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
     $Param{RateSearchSelectionString} = $LayoutObject->BuildSelection(
         Data => {
@@ -1448,9 +1449,9 @@ sub MaskForm {
         Sort        => 'NumericKey',
         Name        => 'RateSearch',
         SelectedID  => $Param{RateSearch} || '',
-        Size        => 1,
         Translation => 0,
         Multiple    => 0,
+        Class       => 'Modernize',
     );
 
     $Param{ItemCreateTimePoint} = $LayoutObject->BuildSelection(


### PR DESCRIPTION
Hi @carlosfrodriguez 

There is PR with update for modern input fields. I contacted @dvuckovic  and team who have worked on this features. They explained me how it works.
I deleted Size param from some BuildSelection functions because always one line is displayed (Size=1 by default ) now. If I am not right, I will be able to go back to the old state about Size param.

Regards
Zoran