### PR TITLE
[Master Bug 11498] - FAQ items dissapear from AgentFAQExplorer when invalid

### DIFF
--- a/CHANGES-FAQ.md
+++ b/CHANGES-FAQ.md
@@ -1,5 +1,6 @@
 #5.0.7 2016-??-??
-- 2016-09-16 Updated Import console command for OTRS 5 patch level 14.
+ - 2016-09-21 Fixed bug#[10923](http://bugs.otrs.org/show_bug.cgi?id=10923)(PR#49)  - Keywords are not searchable, thanks to S7.
+ - 2016-09-16 Updated Import console command for OTRS 5 patch level 14.
 
 #5.0.6 2016-09-20
  - 2016-09-14 Updated translations, thanks to all translators.

--- a/Kernel/Config/Files/FAQ.xml
+++ b/Kernel/Config/Files/FAQ.xml
@@ -1012,6 +1012,17 @@ Your OTRS Notification Master
             <String Regex="^[0-9]{1,3}$">50</String>
         </Setting>
     </ConfigItem>
+    <ConfigItem Name="FAQ::Frontend::AgentFAQExplorer###ShowInvalidFAQItems" Required="1" Valid="1">
+        <Description Translatable="1">Show invalid items in the FAQ Explorer result of the agent interface.</Description>
+        <Group>FAQ</Group>
+        <SubGroup>Frontend::Agent::FAQ::ViewExplorer</SubGroup>
+        <Setting>
+            <Option SelectedID="0">
+                <Item Key="0">No</Item>
+                <Item Key="1">Yes</Item>
+            </Option>
+        </Setting>
+    </ConfigItem>
     <ConfigItem Name="PreferencesGroups###FAQOverviewSmallPageShown" Required="0" Valid="1">
         <Description Translatable="1">Parameters for the pages (in which the FAQ items are shown) of the small FAQ overview.</Description>
         <Group>FAQ</Group>

--- a/Kernel/Modules/AgentFAQExplorer.pm
+++ b/Kernel/Modules/AgentFAQExplorer.pm
@@ -197,11 +197,19 @@ sub Run {
     );
 
     # get all items (valid and invalid) if SySConfig is set
-    my $ValidIDs;
+    my $ValidObject = $Kernel::OM->Get('Kernel::System::Valid');
+    my @ValidIDs;
     my $Valid = 1;
     if ( $Config->{ShowInvalidFAQItems} ) {
-        $ValidIDs = keys { $Kernel::OM->Get('Kernel::System::Valid')->ValidList() };
+        @ValidIDs = keys { $ValidObject->ValidList() };
         $Valid = 0;
+    }
+    else {
+        @ValidIDs = (
+            $ValidObject->ValidLookup(
+                Valid => 'valid',
+            )
+            )
     }
 
     # check if there are subcategories
@@ -258,7 +266,7 @@ sub Run {
         States           => $InterfaceStates,
         Interface        => $Interface,
         CategoryIDs      => [$CategoryID],
-        ValidIDs         => $ValidIDs,
+        ValidIDs         => \@ValidIDs,
     );
 
     # build necessary stuff for the FAQ article list

--- a/Kernel/Modules/AgentFAQExplorer.pm
+++ b/Kernel/Modules/AgentFAQExplorer.pm
@@ -196,6 +196,14 @@ sub Run {
         UserID => $Self->{UserID},
     );
 
+    # get all items (valid and invalid) if SySConfig is set
+    my $ValidIDs;
+    my $Valid = 1;
+    if ( $Config->{ShowInvalidFAQItems} ) {
+        $ValidIDs = keys { $Kernel::OM->Get('Kernel::System::Valid')->ValidList() };
+        $Valid = 0;
+    }
+
     # check if there are subcategories
     if ( $CategoryIDsRef && ref $CategoryIDsRef eq 'ARRAY' && @{$CategoryIDsRef} ) {
 
@@ -219,6 +227,7 @@ sub Run {
                 CategoryIDs  => [$SubCategoryID],
                 ItemStates   => $InterfaceStates,
                 OnlyApproved => 0,
+                Valid        => $Valid,
                 UserID       => $Self->{UserID},
             );
 
@@ -249,6 +258,7 @@ sub Run {
         States           => $InterfaceStates,
         Interface        => $Interface,
         CategoryIDs      => [$CategoryID],
+        ValidIDs         => $ValidIDs,
     );
 
     # build necessary stuff for the FAQ article list

--- a/Kernel/Modules/AgentFAQSearch.pm
+++ b/Kernel/Modules/AgentFAQSearch.pm
@@ -493,7 +493,7 @@ sub Run {
         # Values are the Category names.
 
         my $UserCatGroup = $FAQObject->GetUserCategories(
-            Type   => 'rw',
+            Type   => 'ro',
             UserID => $Self->{UserID},
         );
 
@@ -1358,7 +1358,7 @@ sub _MaskForm {
 
     # get categories (with category long names) where user has rights
     my $UserCategoriesLongNames = $FAQObject->GetUserCategoriesLongNames(
-        Type   => 'rw',
+        Type   => 'ro',
         UserID => $Self->{UserID},
     );
 

--- a/Kernel/Modules/AgentFAQSearchSmall.pm
+++ b/Kernel/Modules/AgentFAQSearchSmall.pm
@@ -487,7 +487,7 @@ sub Run {
         # Values are the Category names.
 
         my $UserCatGroup = $FAQObject->GetUserCategories(
-            Type   => 'rw',
+            Type   => 'ro',
             UserID => $Self->{UserID},
         );
 
@@ -741,7 +741,7 @@ sub _MaskForm {
 
     # get categories (with category long names) where user has rights
     my $UserCategoriesLongNames = $FAQObject->GetUserCategoriesLongNames(
-        Type   => 'rw',
+        Type   => 'ro',
         UserID => $Self->{UserID},
     );
 

--- a/Kernel/Modules/CustomerFAQExplorer.pm
+++ b/Kernel/Modules/CustomerFAQExplorer.pm
@@ -174,6 +174,7 @@ sub Run {
                 CategoryIDs  => [$SubCategoryID],
                 ItemStates   => $InterfaceStates,
                 OnlyApproved => 1,
+                Valid        => 1,
                 UserID       => $Self->{UserID},
             );
 

--- a/Kernel/Modules/PublicFAQExplorer.pm
+++ b/Kernel/Modules/PublicFAQExplorer.pm
@@ -200,6 +200,7 @@ sub Run {
                 CategoryIDs  => [$SubCategoryID],
                 ItemStates   => $InterfaceStates,
                 OnlyApproved => 1,
+                Valid        => 1,
                 UserID       => $Self->{UserID},
             );
 

--- a/Kernel/System/FAQ.pm
+++ b/Kernel/System/FAQ.pm
@@ -1196,6 +1196,7 @@ Count the number of articles for a defined category. Only valid FAQ articles wil
     my $ArticleCount = $FAQObject->FAQCount(
         CategoryIDs  => [1,2,3,4],
         OnlyApproved => 1,   # optional (default 0)
+        Valid        => 1,   # optional (default 0)
         UserID       => 1,
     );
 
@@ -1219,6 +1220,9 @@ sub FAQCount {
             return;
         }
     }
+
+    # set default value
+    my $Valid = $Param{Valid} ? 1 : 0;
 
     # get database object
     my $DBObject = $Kernel::OM->Get('Kernel::System::DB');
@@ -1252,7 +1256,13 @@ sub FAQCount {
     }
 
     # build valid id string
-    my $ValidIDsString = join ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+    my $ValidIDsString;
+    if ($Valid) {
+        $ValidIDsString = join ', ', $Kernel::OM->Get('Kernel::System::Valid')->ValidIDsGet();
+    }
+    else {
+        $ValidIDsString = join ', ', keys { $Kernel::OM->Get('Kernel::System::Valid')->ValidList() };
+    }
 
     my $SQL = 'SELECT COUNT(*) '
         . 'FROM faq_item i, faq_state s '


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11498
Hi @carlosfrodriguez 

Here is our proposal for fixing this bug. 
My idea was that we allow agents to see invalid FAQ items. I believe that this feature is not needed for customer and public interface. Please, let me know what do you think about that.

Regards
Zoran