### PR TITLE
[ Master FAQ  Bug 11158 ]- Only ro priviledge's user cannot search FAQ 

### DIFF
--- a/Kernel/Modules/AgentFAQSearch.pm
+++ b/Kernel/Modules/AgentFAQSearch.pm
@@ -1358,7 +1358,7 @@ sub _MaskForm {
 
     # get categories (with category long names) where user has rights
     my $UserCategoriesLongNames = $FAQObject->GetUserCategoriesLongNames(
-        Type   => 'rw',
+        Type   => 'ro',
         UserID => $Self->{UserID},
     );
 

--- a/Kernel/Modules/AgentFAQSearch.pm
+++ b/Kernel/Modules/AgentFAQSearch.pm
@@ -493,7 +493,7 @@ sub Run {
         # Values are the Category names.
 
         my $UserCatGroup = $FAQObject->GetUserCategories(
-            Type   => 'rw',
+            Type   => 'ro',
             UserID => $Self->{UserID},
         );
 

--- a/Kernel/Modules/AgentFAQSearchSmall.pm
+++ b/Kernel/Modules/AgentFAQSearchSmall.pm
@@ -487,7 +487,7 @@ sub Run {
         # Values are the Category names.
 
         my $UserCatGroup = $FAQObject->GetUserCategories(
-            Type   => 'rw',
+            Type   => 'ro',
             UserID => $Self->{UserID},
         );
 

--- a/Kernel/Modules/AgentFAQSearchSmall.pm
+++ b/Kernel/Modules/AgentFAQSearchSmall.pm
@@ -741,7 +741,7 @@ sub _MaskForm {
 
     # get categories (with category long names) where user has rights
     my $UserCategoriesLongNames = $FAQObject->GetUserCategoriesLongNames(
-        Type   => 'rw',
+        Type   => 'ro',
         UserID => $Self->{UserID},
     );
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=10923

Hi @carlosfrodriguez ,

Hereby is proposed fix for this issue. Before users with 'ro' permission in FAQ group couldn't search for FAQ's, since category search was based on users with 'rw' permission.

Please let me know what do you think about this proposal.

Regards,
Sanjin 