### PR TITLE
[ Master FAQ Bug 11580 ] - FAQ bread crumb navigation is wrong / missing the actual item category

### DIFF
--- a/Kernel/Modules/AgentFAQZoom.pm
+++ b/Kernel/Modules/AgentFAQZoom.pm
@@ -497,10 +497,11 @@ sub Run {
 
     # show FAQ path
     my $ShowFAQPath = $LayoutObject->FAQPathShow(
-        FAQObject  => $FAQObject,
-        CategoryID => $FAQData{CategoryID},
-        UserID     => $Self->{UserID},
-        Nav        => $Nav,
+        FAQObject   => $FAQObject,
+        CategoryID  => $FAQData{CategoryID},
+        UserID      => $Self->{UserID},
+        PathForItem => 1,
+        Nav         => $Nav,
     );
     if ($ShowFAQPath) {
         $LayoutObject->Block(

--- a/Kernel/Modules/CustomerFAQZoom.pm
+++ b/Kernel/Modules/CustomerFAQZoom.pm
@@ -415,9 +415,10 @@ sub Run {
 
     # show FAQ path
     my $ShowFAQPath = $LayoutObject->FAQPathShow(
-        FAQObject  => $FAQObject,
-        CategoryID => $FAQData{CategoryID},
-        UserID     => $Self->{UserID},
+        FAQObject   => $FAQObject,
+        CategoryID  => $FAQData{CategoryID},
+        PathForItem => 1,
+        UserID      => $Self->{UserID},
     );
     if ($ShowFAQPath) {
         $LayoutObject->Block(

--- a/Kernel/Modules/PublicFAQZoom.pm
+++ b/Kernel/Modules/PublicFAQZoom.pm
@@ -285,9 +285,10 @@ sub Run {
 
     # show FAQ path
     my $ShowFAQPath = $LayoutObject->FAQPathShow(
-        FAQObject  => $FAQObject,
-        CategoryID => $FAQData{CategoryID},
-        UserID     => $Self->{UserID},
+        FAQObject   => $FAQObject,
+        CategoryID  => $FAQData{CategoryID},
+        PathForItem => 1,
+        UserID      => $Self->{UserID},
     );
     if ($ShowFAQPath) {
         $LayoutObject->Block(

--- a/Kernel/Output/HTML/Layout/FAQ.pm
+++ b/Kernel/Output/HTML/Layout/FAQ.pm
@@ -568,6 +568,7 @@ and returns the value 1.
         FAQObject   => $FAQObject,                   # needed for core module interaction
         CategoryID  => 5,
         UserID      => 1,
+        PathForItem => 1,                            # optional (default 0)
         Nav         => 'none',                       # optional
     );
 
@@ -586,6 +587,8 @@ sub FAQPathShow {
             return;
         }
     }
+
+    $Param{PathForItem} ||= 0;
 
     # check parameters
     if ( !defined $Param{CategoryID} ) {
@@ -632,8 +635,12 @@ sub FAQPathShow {
     # output subcategories
     for my $CategoryData ( @{$CategoryList} ) {
 
-        my $Block = 'FAQPathCategoryElement';
-        if ( $CategoryData->{CategoryID} == $CategoryList->[-1]->{CategoryID} ) {
+        $Block = 'FAQPathCategoryElement';
+        if (
+            $CategoryData->{CategoryID} == $CategoryList->[-1]->{CategoryID}
+            && !$Param{PathForItem}
+            )
+        {
             $Block = 'FAQPathCategoryElementNoLink';
         }
 


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11580

Hi @carlosfrodriguez ,

Hereby is proposal for fixing this issue. Added param for Zoom screens for FAQPathShow function that makes distinction between explorer and zoom behaviour for bread crumbs navigation. This way, last subcategory will not be lost in navigation when accessing FAQ item from that subcategory.

Please let me know if you have any questions or issues with this proposal.

Regards,
Sanjin