### PR TITLE
[ Master FAQ Bug 11122 ] - Dashlet: MouseOver in a Linktitle

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentDashboardFAQOverview.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentDashboardFAQOverview.tt
@@ -12,7 +12,7 @@
 [% RenderBlockStart("InfoBoxFAQMiniListItemRow") %]
         <tr>
             <td>
-                <a href="[% Env("Baselink") %]Action=AgentFAQZoom;ItemID=[% Data.ItemID | uri %]" class="AsBlock" title="[% Data.Title | html %] ([% Data.CategoryName | uri %])">
+                <a href="[% Env("Baselink") %]Action=AgentFAQZoom;ItemID=[% Data.ItemID | uri %]" class="AsBlock" title="[% Data.Title | html %] ([% Data.CategoryName | html %])">
                     [% Data.Title | truncate(50) | html %]
                 </a>
                 <span>


### PR DESCRIPTION
http://bugs.otrs.org/show_bug.cgi?id=11122 

Hi @carlosfrodriguez ,

Heres fix for this bug. There was missing title encoding for category name for FAQ in dashboard widgets.

Regards,
Sanjin 
