### PR TITLE
Switched rights from rw to ro for AgentFAQSearch.

### DIFF
--- a/Kernel/Modules/AgentFAQSearch.pm
+++ b/Kernel/Modules/AgentFAQSearch.pm
@@ -493,7 +493,7 @@ sub Run {
         # Values are the Category names.
 
         my $UserCatGroup = $FAQObject->GetUserCategories(
-            Type   => 'rw',
+            Type   => 'ro',
             UserID => $Self->{UserID},
         );
 


### PR DESCRIPTION
This commit fixes a bug preventing Agents from finding FAQs stored in categories they just have 'ro' permission for.

Those FAQ's can be accessed by these Agents using the FAQ Explorer, but not using AgentFAQSearch.
