### PR TITLE
Fixed bug#12201 - RSS feed invalid links on https

### DIFF
--- a/Kernel/Modules/PublicFAQRSS.pm
+++ b/Kernel/Modules/PublicFAQRSS.pm
@@ -112,7 +112,11 @@ sub Run {
     }
 
     # create RSS object object
-    my $RSSObject = XML::RSS::SimpleGen->new( 'http://' . $ENV{HTTP_HOST} );
+    my $RSSObject = XML::RSS::SimpleGen->new(
+        $ConfigObject->Get("HttpType")
+        . '://'
+        . $ConfigObject->Get("FQDN")
+    );
 
     # generate the RSS title
     $Title = $ConfigObject->Get('ProductName') . ' ' . $Title;
@@ -144,7 +148,13 @@ sub Run {
 
         # build the RSS item
         $RSSObject->item(
-            "http://$ENV{HTTP_HOST}$LayoutObject->{Baselink}Action=PublicFAQZoom&ItemID=$ItemID",
+            $ConfigObject->Get('HttpType')
+            . "://"
+            . $ConfigObject->Get("FQDN")
+            . "/"
+            . $ConfigObject->Get("ScriptAlias")
+            . $LayoutObject->{Baselink}
+            . "Action=PublicFAQZoom;ItemID=$ItemID",
             $ItemData{Title},
             $Preview,
         );


### PR DESCRIPTION
If OTRS is configured to use HTTPS, this is not reflected in the URLs in
the RSS feed for the FAQ. This PR fixes that.

https://bugs.otrs.org/show_bug.cgi?id=12201