### PR TITLE
title length of FAQ extended to 100 characters

### DIFF
--- a/Kernel/Config/Files/XML/FAQ.xml
+++ b/Kernel/Config/Files/XML/FAQ.xml
@@ -187,7 +187,7 @@
         <Description Translatable="1">Default maximum size of the titles in a FAQ article to be shown.</Description>
         <Navigation>Core::FAQ</Navigation>
         <Value>
-            <Item ValueType="String" ValueRegex="^[0-9]{1,3}$">50</Item>
+            <Item ValueType="String" ValueRegex="^[0-9]{1,3}$">100</Item>
         </Value>
     </Setting>
     <Setting Name="FAQ::Default::State" Required="1" Valid="1">


### PR DESCRIPTION
50 is too short for a good title